### PR TITLE
Adding streaming service settings persistence per issue #1

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,12 @@
+/* Streaming Sources Styles */
+.search-settings {
+    background-color: lightgray;
+    padding: 10px;
+    margin-top: 5px;
+}
+
+.streaming-sources {
+    margin: 0 10px;
+    padding: 10px;
+}
+

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,57 @@
+var saveSettingsBtnEl = document.querySelector("#save-settings")
+
+// Initialize empty array to store streaming service settings
+var streamingSettings = []
+
+var saveSettingsHandler = function(event) {
+    event.preventDefault()
+
+    // reinitialize the value of the array back to zero at each save since they're resetting their values
+    streamingSettings = []
+
+    // grab the labels for all of the materialize checkboxes
+    var streamingServiceLabels = document.querySelectorAll(".streaming-sources")
+
+    // loop through the values of the labels since we can't directly searched for checked attribute with materialize checkboxes
+    for(var i = 0; i < streamingServiceLabels.length; i++) {
+        // get the name of the service associated with the checkbox
+        var getServiceName = streamingServiceLabels[i].getAttribute("for")
+
+        // set a variable to capture whether the service provider is selected
+        var isChecked = document.getElementById(getServiceName).checked
+
+        // if the streaming service is selected, add it to the streaming settings list
+        if (isChecked) {
+
+            streamingSettings.push(getServiceName)
+        }
+
+    }
+
+    //save the settings to local storage
+    saveSettings(streamingSettings)
+}
+
+// save the settings to local storage
+var saveSettings = function(array) {
+    localStorage.setItem("user-settings", JSON.stringify(array));
+}
+
+// load user settings from local storage
+var loadSettings = function() {
+    streamingSettings = JSON.parse(localStorage.getItem("user-settings"))
+
+    // if nothing in localStorage, set the user settings back to an empty array
+    if (!streamingSettings) {
+        streamingSettings = []
+    }
+    // find the checkbox with the correct ID and set the checked element to checked on load
+    for (var i = 0; i < streamingSettings.length; i++) {
+        var streamingCheckBox = document.getElementById(streamingSettings[i])
+        streamingCheckBox.setAttribute("checked","checked")
+    }
+}
+
+loadSettings()
+// save the settings when a user clicks the Save Settings button
+saveSettingsBtnEl.addEventListener("click" , saveSettingsHandler)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>I Stream, U Stream</title>
+    <!-- Materialize CSS Link -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
+    <link rel="stylesheet" href="./assets/css/styles.css">
+</head>
+<body>
+    <header>
+        <div>
+            <h1>
+                I Stream, U Stream
+            </h1>
+        </div>
+        <div class="row search-settings valign-wrapper">
+            <div class="col s8" id="streaming-settings">
+                <p>
+                    Select your streaming service providers:
+                </p>
+                <form>
+                    <label class="streaming-sources" for="netflix">
+                        <input type="checkbox" id="netflix" />
+                        <span>Netflix</span>
+                    </label>
+                    <label class="streaming-sources" for="hulu">
+                        <input type="checkbox" id="hulu" />
+                        <span>Hulu</span>
+                    </label>
+                    <label class="streaming-sources" for="prime">
+                        <input type="checkbox" id="prime" />
+                        <span>Prime</span>
+                    </label>
+                    <label class="streaming-sources" for="hbomax">
+                        <input type="checkbox" id="hbomax" />
+                        <span>HBO MAX</span>
+                    </label>
+                    <label class="streaming-sources" for="disney">
+                        <input type="checkbox" id="disney" />
+                        <span>Disney+</span>
+                    </label>
+                    <button class="btn waves-effect waves-light" type="submit" name="save-settings" id="save-settings">Save Settings</button>
+                </form>
+            </div>
+
+                <div class="input-field col s2">
+                    <input id="actor_query" type="text" class="validate">
+                    <label for="actor_query">Search</label>
+                </div>
+                <div class="col s2">
+                    <button class="btn waves-effect waves-light" type="submit" name="search-query" id="search-query">Submit</button>
+                </div>
+        </div>
+    </header>
+    <main>
+    </main>
+    
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="./assets/js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
For now, this feature just gets the name of the service they've selected and saves it to an array in local storage. We can add more fields to that as necessary, but I kept in simple for now since we need to think through how we expect the data to flow.

This change also includes very basic UI to display the settings that we'll need to clean up.

